### PR TITLE
feat: added optional prefix to vm names

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -20,17 +20,16 @@ variable "talos" {
       primary_dns_server   = string
       secondary_dns_server = string
       ntp_endpoint         = string
+      node_prefix = string
       control_plane = object({
         cpu   = string
         memory = string
         nodes = map(object({}))
-        node_prefix = string
       })
       worker = object({
         cpu    = string
         memory = string
         nodes  = map(object({}))
-        node_prefix = string
       })
     })
   })

--- a/variables.tf
+++ b/variables.tf
@@ -24,11 +24,13 @@ variable "talos" {
         cpu   = string
         memory = string
         nodes = map(object({}))
+        node_prefix = string
       })
       worker = object({
         cpu    = string
         memory = string
         nodes  = map(object({}))
+        node_prefix = string
       })
     })
   })

--- a/variables.tf
+++ b/variables.tf
@@ -20,7 +20,7 @@ variable "talos" {
       primary_dns_server   = string
       secondary_dns_server = string
       ntp_endpoint         = string
-      node_prefix = string
+      node_prefix          = optional(string, "")
       control_plane = object({
         cpu   = string
         memory = string

--- a/vms.tf
+++ b/vms.tf
@@ -24,8 +24,8 @@ resource "proxmox_virtual_environment_vm" "this" {
       }
     )
   }
-  
-  name      = format("%s-%s", each.value.type == "controlplane" && var.talos.node_data.control_plane.node_prefix != ""  ? var.talos.node_data.control_plane.node_prefix  : each.value.type == "worker" && var.talos.node_data.worker.node_prefix != ""  ? var.talos.node_data.worker.node_prefix  : each.value.type, random_string.this[each.key].result)
+
+  name      = format("%s-%s-%s", var.talos.node_data.node_prefix ,each.value.type, random_string.this[each.key].result)
   node_name = "${var.talos.node_data.node_name}"
   tags      = ["terraform", "talos"]
   vm_id     = random_integer.this[each.key].result

--- a/vms.tf
+++ b/vms.tf
@@ -24,8 +24,8 @@ resource "proxmox_virtual_environment_vm" "this" {
       }
     )
   }
-
-  name      = format("%s-%s", each.value.type, random_string.this[each.key].result)
+  
+  name      = format("%s-%s", each.value.type == "controlplane" && var.talos.node_data.control_plane.node_prefix != ""  ? var.talos.node_data.control_plane.node_prefix  : each.value.type == "worker" && var.talos.node_data.worker.node_prefix != ""  ? var.talos.node_data.worker.node_prefix  : each.value.type, random_string.this[each.key].result)
   node_name = "${var.talos.node_data.node_name}"
   tags      = ["terraform", "talos"]
   vm_id     = random_integer.this[each.key].result

--- a/vms.tf
+++ b/vms.tf
@@ -24,8 +24,8 @@ resource "proxmox_virtual_environment_vm" "this" {
       }
     )
   }
-
-  name      = format("%s-%s-%s", var.talos.node_data.node_prefix ,each.value.type, random_string.this[each.key].result)
+  
+  name      = var.talos.node_data.node_prefix != ""  ? format( "%s-%s-%s" , var.talos.node_data.node_prefix ,each.value.type, random_string.this[each.key].result) : format( "%s-%s" ,each.value.type, random_string.this[each.key].result)
   node_name = "${var.talos.node_data.node_name}"
   tags      = ["terraform", "talos"]
   vm_id     = random_integer.this[each.key].result

--- a/vms.tf
+++ b/vms.tf
@@ -24,8 +24,8 @@ resource "proxmox_virtual_environment_vm" "this" {
       }
     )
   }
-  
-  name      = var.talos.node_data.node_prefix != ""  ? format( "%s-%s-%s" , var.talos.node_data.node_prefix ,each.value.type, random_string.this[each.key].result) : format( "%s-%s" ,each.value.type, random_string.this[each.key].result)
+
+  name      = format("%s%s-%s", var.talos.node_data.node_prefix ,each.value.type, random_string.this[each.key].result)
   node_name = "${var.talos.node_data.node_name}"
   tags      = ["terraform", "talos"]
   vm_id     = random_integer.this[each.key].result


### PR DESCRIPTION
Added optional vm name prefix.

**Requirements:**

- Add node_prefix = string to var.talos.node_data
**Use:**

In terraform.auto.tfvars (or opentofu.auto.tfvars), either define a prefix using var.talos.node_data.node_prefix  or leave var.talos.node_data.node_prefix blank to use the inbuilt pre-fix's.

  node_data = {
    node_prefix = ""
  }

**OR**

  node_data = {
    node_prefix = "example-prefix"
  }

 