### PR TITLE
feat(vm): ignore iso changes to vm

### DIFF
--- a/vms.tf
+++ b/vms.tf
@@ -95,6 +95,10 @@ resource "proxmox_virtual_environment_vm" "this" {
     bridge = "vmbr0"
   }
 
+  lifecycle {
+    ignore_changes = [disk[0].file_id]
+  }
+
   depends_on = [
     proxmox_virtual_environment_download_file.this
   ]


### PR DESCRIPTION
When upgrading Talos Linux currently, changing `talos_version` pulls down a new ISO and replaces all VM's at once with the new image, this causing an outage on the cluster as zero nodes are available. This change adds a lifecycle to ignore any ISO changes so `talosctl upgrade` can be ran in a pipeline to upgrade each node individually. 